### PR TITLE
Fix demo page, restore original parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,10 @@
   <br>
   <br>
   <img class="js-lazy-image centered" src="./img/dog-battersea.svg" width="400" height="400" data-src="./img/dog-battersea.jpg">
-  <script src="lazy-load.min.js"></script>
+  <script type="module">
+    import LazyLoad from "./lazy-load.js";
+    LazyLoad.init();
+  </script>
 </body>
 
 </html>

--- a/lazy-load.js
+++ b/lazy-load.js
@@ -12,7 +12,7 @@ let config,
     observer;
 
 /**
- * Fetchs the image for the given URL
+ * Fetches the image for the given URL
  * @param {string} url
  */
 function fetchImage(url) {
@@ -29,7 +29,7 @@ function fetchImage(url) {
  * @param {object} image
  */
 function preloadImage(image) {
-  const src = image.dataset.original;
+  const src = image.dataset.src;
   if (!src) {
     return;
   }


### PR DESCRIPTION
Fixed the way the demo calls the library
Also restored the original parameter "data-src", accidentaly renamed it to "data-original" in my code